### PR TITLE
Parse OFX without balance date

### DIFF
--- a/lib/ofx/parser/bank.ex
+++ b/lib/ofx/parser/bank.ex
@@ -62,7 +62,7 @@ defmodule Ofx.Parser.Bank do
 
   defp build_balance(balance, balance_date, currency) do
     %{
-      date: Datetime.format(balance_date),
+      date: format_balance_date(balance_date),
       amount: Currency.amount_to_float(balance),
       int_positive_amount: Currency.amount_to_positive_integer(balance, currency),
       amount_type: Currency.amount_type(balance)
@@ -93,4 +93,7 @@ defmodule Ofx.Parser.Bank do
       date -> Datetime.format(date)
     end
   end
+
+  defp format_balance_date(""), do: nil
+  defp format_balance_date(balance_date), do: Datetime.format(balance_date)
 end

--- a/test/ofx/parser/bank_test.exs
+++ b/test/ofx/parser/bank_test.exs
@@ -189,5 +189,60 @@ defmodule Ofx.Parser.BankTest do
         Bank.format(bank_example)
       end
     end
+
+    test "returns date as nil when there is not date on balance info" do
+      bank_msg = """
+      <BANKMSGSRSV1>
+      <STMTTRNRS>
+      <STATUS>
+      <CODE>0</CODE>
+      <SEVERITY>INFO</SEVERITY>
+      </STATUS>
+      <STMTRS>
+      <CURDEF>BRL</CURDEF>
+      <BANKACCTFROM>
+      <ACCTTYPE>CHECKING</ACCTTYPE>
+      </BANKACCTFROM>
+      <LEDGERBAL>
+      <BALAMT>0.00</BALAMT>
+      </LEDGERBAL>
+      </STMTRS>
+      </STMTTRNRS>
+      </BANKMSGSRSV1>
+      """
+
+      bank_example =
+        bank_msg
+        |> SweetXml.parse()
+        |> SweetXml.xpath(~x"//BANKMSGSRSV1")
+
+      result = Bank.format(bank_example)
+
+      assert result == [
+               %{
+                 account_id: "",
+                 account_type: "checking",
+                 balance: %{
+                   amount: 0.0,
+                   amount_type: :credit,
+                   date: nil,
+                   int_positive_amount: 0
+                 },
+                 currency: "BRL",
+                 description: "",
+                 request_id: "",
+                 routing_number: "",
+                 status: %{
+                   code: 0,
+                   severity: :info
+                 },
+                 transactions: %{
+                   end_date: nil,
+                   list: [],
+                   start_date: nil
+                 }
+               }
+             ]
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Some banks does not include the balance date in the OFX file.

### Proposal solution

Support this scenario, parsing it successfully.