### PR TITLE
New format for currency and datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `ofx` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ofx, "~> 0.0.11"}
+    {:ofx, "~> 0.0.12"}
   ]
 end
 ```

--- a/lib/ofx.ex
+++ b/lib/ofx.ex
@@ -1,4 +1,6 @@
 defmodule Ofx do
+  @moduledoc false
+
   defdelegate parse(ofx), to: Ofx.Parser
   defdelegate parse!(ofx), to: Ofx.Parser
 end

--- a/lib/ofx/parser.ex
+++ b/lib/ofx/parser.ex
@@ -1,4 +1,6 @@
 defmodule Ofx.Parser do
+  @moduledoc false
+
   import Ofx.Parser.Utils
 
   import SweetXml, only: [xpath: 2, sigil_x: 2]

--- a/lib/ofx/parser/currency.ex
+++ b/lib/ofx/parser/currency.ex
@@ -5,6 +5,7 @@ defmodule Ofx.Parser.Currency do
 
   def amount_to_positive_integer(amount, currency) do
     amount
+    |> sanitize_string()
     |> amount_to_float()
     |> remove_decimal(currency)
     |> abs()
@@ -186,5 +187,11 @@ defmodule Ofx.Parser.Currency do
     }
 
     currency_decimails[currency]
+  end
+
+  defp sanitize_string(str) do
+    str
+    |> String.replace("R$", "")
+    |> String.trim()
   end
 end

--- a/lib/ofx/parser/currency.ex
+++ b/lib/ofx/parser/currency.ex
@@ -22,6 +22,7 @@ defmodule Ofx.Parser.Currency do
   def amount_to_float(amount) do
     {float, _rest} =
       amount
+      |> sanitize_string()
       |> String.replace(~r/\s/, "")
       |> String.replace(",", ".")
       |> Float.parse()

--- a/lib/ofx/parser/datetime.ex
+++ b/lib/ofx/parser/datetime.ex
@@ -53,6 +53,7 @@ defmodule Ofx.Parser.Datetime do
 
   def format(input) when is_binary(input) do
     input
+    |> format_date()
     |> to_struct()
     |> adjust_microsecond()
     |> adjust_time_zone()
@@ -65,6 +66,15 @@ defmodule Ofx.Parser.Datetime do
   end
 
   def format(input), do: raise_error(input)
+
+  defp format_date(input) do
+    if Regex.match?(~r/^\d{2}\/\d{2}\/\d{4}$/, input) do
+      [d, m, y] = String.split(input, "/")
+      "#{y}#{m}#{d}"
+    else
+      input
+    end
+  end
 
   defp to_struct(input) do
     case Regex.named_captures(@datetime_regex, input) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Ofx.MixProject do
   use Mix.Project
 
-  @version "0.0.11"
+  @version "0.0.12"
   @description "A lib to parse and generate OFX data"
   @links %{"GitHub" => "https://github.com/danielwsx64/ofx"}
 

--- a/test/ofx/parser/currency_test.exs
+++ b/test/ofx/parser/currency_test.exs
@@ -58,6 +58,19 @@ defmodule Ofx.Parser.CurrencyTest do
       assert Currency.amount_to_positive_integer(negative, currency) == 500
     end
 
+    test "convert successfully when there R$ symbol" do
+      currency = "BRL"
+      without_decimal = "R$ 500"
+      one_decimal = "R$500.1"
+      two_decimals = "R$ 500.10 "
+      negative = "R$ -500.1"
+
+      assert Currency.amount_to_positive_integer(without_decimal, currency) == 50_000
+      assert Currency.amount_to_positive_integer(one_decimal, currency) == 50_010
+      assert Currency.amount_to_positive_integer(two_decimals, currency) == 50_010
+      assert Currency.amount_to_positive_integer(negative, currency) == 50_010
+    end
+
     test "raise exception when currency is invalid" do
       assert_raise Error, "Amount is invalid or currency is unknown", fn ->
         Currency.amount_to_positive_integer("100", "reais")

--- a/test/ofx/parser/datetime_test.exs
+++ b/test/ofx/parser/datetime_test.exs
@@ -137,6 +137,25 @@ defmodule Ofx.Parser.DateTimeTest do
                }
     end
 
+    test "format date without time with BRL format" do
+      date_without_time = "07/02/2025"
+
+      assert Datetime.format(date_without_time) ==
+               %DateTime{
+                 year: 2025,
+                 month: 2,
+                 day: 7,
+                 hour: 0,
+                 minute: 0,
+                 second: 0,
+                 microsecond: {0, 3},
+                 time_zone: "UTC",
+                 zone_abbr: "UTC",
+                 utc_offset: 0,
+                 std_offset: 0
+               }
+    end
+
     test "format EST timezone" do
       est_tz = "20210218100000[-05:EST]"
 

--- a/test/ofx/parser_test.exs
+++ b/test/ofx/parser_test.exs
@@ -656,7 +656,7 @@ defmodule Ofx.ParserTest do
                          ref_num: "077",
                          currency: "BRL",
                          fit_id: "12/04/2021077",
-                         int_positive_amount: 15990,
+                         int_positive_amount: 15_990,
                          memo: "PAGAMENTO CASHBACK 9832-01",
                          name: "",
                          posted_date: %DateTime{
@@ -681,7 +681,7 @@ defmodule Ofx.ParserTest do
                          ref_num: "077",
                          currency: "BRL",
                          fit_id: "05/05/2021077",
-                         int_positive_amount: 15990,
+                         int_positive_amount: 15_990,
                          memo: "PAGAMENTO FATURA INTER - Pagamento Fatura Cartão Inter",
                          name: "",
                          posted_date: %DateTime{
@@ -731,7 +731,7 @@ defmodule Ofx.ParserTest do
                          ref_num: "077",
                          currency: "BRL",
                          fit_id: "07/06/2021077",
-                         int_positive_amount: 22000,
+                         int_positive_amount: 22_000,
                          memo: "PIX RECEBIDO - Cp :98127- Jonny",
                          name: "",
                          posted_date: %DateTime{
@@ -756,7 +756,7 @@ defmodule Ofx.ParserTest do
                          ref_num: "077",
                          currency: "BRL",
                          fit_id: "07/06/2021077",
-                         int_positive_amount: 21990,
+                         int_positive_amount: 21_990,
                          memo: "PAGAMENTO FATURA INTER - Débito Automático Fatura Cartão Inter",
                          name: "",
                          posted_date: %DateTime{


### PR DESCRIPTION
PagSeguro uses a different format for currency (R$ 10,606.10) and datetime (07/02/2025), which is breaking our integration. The purpose of these changes is to enhance our range of possibilities.

EXTRA: I fixed the credo warnings







